### PR TITLE
initial csv logic for cosmogragh. Now paths use site of call instead of enclosing func

### DIFF
--- a/cmd/map.go
+++ b/cmd/map.go
@@ -43,7 +43,7 @@ func init() {
 	mapCmd.PersistentFlags().StringVarP(&filter, "filter", "f", "", "Filter package for call graph search")
 	mapCmd.PersistentFlags().IntVarP(&limiter, "rec-limit", "l", 0, "Limit the max number of recursive calls wally makes when mapping call stacks")
 	mapCmd.PersistentFlags().BoolVar(&printNodes, "print-nodes", false, "Print the position of call graph paths rather than node")
-	mapCmd.PersistentFlags().StringVar(&format, "format", "", "Output format. Supported: json")
+	mapCmd.PersistentFlags().StringVar(&format, "format", "", "Output format. Supported: json, csv")
 	mapCmd.PersistentFlags().StringVarP(&outputFile, "out", "o", "", "Output to file path")
 }
 

--- a/navigator/navigator.go
+++ b/navigator/navigator.go
@@ -339,6 +339,10 @@ func (n *Navigator) PrintResults(format string, fileName string) {
 		if err := reporter.PrintJson(n.RouteMatches, fileName); err != nil {
 			n.Logger.Error("Error printing to json", "error", err.Error())
 		}
+	} else if format == "csv" {
+		if err := reporter.WriteCSVFile(n.RouteMatches, fileName); err != nil {
+			n.Logger.Error("Error printing CSV", "error", err.Error())
+		}
 	} else {
 		reporter.PrintResults(n.RouteMatches)
 	}

--- a/wallylib/util.go
+++ b/wallylib/util.go
@@ -1,6 +1,13 @@
 package wallylib
 
-import "go/types"
+import (
+	"fmt"
+	"go/token"
+	"go/types"
+	"golang.org/x/tools/go/ssa"
+	"os"
+	"path/filepath"
+)
 
 func DedupPaths(paths [][]string) [][]string {
 	result := [][]string{}
@@ -42,4 +49,12 @@ func IsLocal(obj types.Object) bool {
 		depth++
 	}
 	return depth >= 4
+}
+
+func GetFormattedPos(pkg *ssa.Package, pos token.Pos) string {
+	fs := pkg.Prog.Fset
+	p := fs.Position(pos)
+	currentPath, _ := os.Getwd()
+	relPath, _ := filepath.Rel(currentPath, p.Filename)
+	return fmt.Sprintf("%s:%d:%d", relPath, p.Line, p.Column)
 }


### PR DESCRIPTION
initial csv logic for cosmogragh. 

Now paths use site of call instead of enclosing fun