### PR TITLE
Logic fixes

### DIFF
--- a/wallylib/callmapper/callmapper.go
+++ b/wallylib/callmapper/callmapper.go
@@ -318,8 +318,12 @@ func passesFilter(node *callgraph.Node, filter string) bool {
 }
 
 func callerInPath(e *callgraph.Edge, paths []string) bool {
+	if e.Caller.Func.Package() == nil {
+		return true
+	}
+	fp := wallylib.GetFormattedPos(e.Caller.Func.Package(), e.Site.Pos())
 	for _, p := range paths {
-		if strings.Contains(p, fmt.Sprintf("[%s]", e.Caller.Func.Name())) {
+		if strings.Contains(p, fp) {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes:

- BFS search was in some cases stopping too soon due to incomplete comparison when checking for duplicate nodes in a path
- When the same function was called in the same enclosing function, the ssa.Instruction was always the first instance. This was fixed