### PR TITLE
Refactor of getnodestring and introduction of module-only

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -40,6 +40,15 @@ var funcCmd = &cobra.Command{
 		if limiterMode > 3 {
 			return fmt.Errorf("limiter-mode should be less than 4, got %d\n", limiterMode)
 		}
+
+		if filter != "" && cmd.Flags().Changed("module-only") && moduleOnly == true {
+			return fmt.Errorf("cannot set module-only to true with a non empty filter (set to %s)", filter)
+		}
+
+		if filter != "" {
+			moduleOnly = false
+		}
+
 		return nil
 	},
 }
@@ -76,6 +85,7 @@ func searchFunc(cmd *cobra.Command, args []string) {
 		Limiter:      callmapper.LimiterMode(limiterMode),
 		SearchAlg:    callmapper.SearchAlgs[searchAlg],
 		SkipClosures: skipClosures,
+		ModuleOnly:   moduleOnly,
 	}
 
 	nav.Logger.Info("Running mapper", "indicators", len(indicators))

--- a/match/match.go
+++ b/match/match.go
@@ -19,6 +19,7 @@ type RouteMatch struct {
 	Pos        token.Position
 	Signature  *types.Signature
 	EnclosedBy string
+	Module     string
 	SSA        *SSAContext
 }
 

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -28,6 +28,7 @@ func PrintMach(match match.RouteMatch) {
 	fmt.Println("Indicator ID: ", match.Indicator.Id)
 	fmt.Println("Package: ", match.Indicator.Package)
 	fmt.Println("Function: ", match.Indicator.Function)
+	fmt.Println("Module: ", match.Module)
 	fmt.Println("Params: ")
 	for k, v := range match.Params {
 		if v == "" {

--- a/sampleapp/main.go
+++ b/sampleapp/main.go
@@ -17,12 +17,13 @@ func ThisIsACall(str string) {
 	fmt.Println(str)
 }
 func printCharSafe(word string, idx int) {
-	safe.RunSafely(func() {
-		printer.PrintOrPanic(word, idx)
-	})
+	safe.RunSafely(
+		func() {
+			printer.PrintOrPanic(word, idx)
+		})
 }
 
 func printChar(word string, idx int) {
 	ThisIsACall("HOOOOLA")
-	printer.PrintOrPanic(word, idx)
+	//printer.PrintOrPanic(word, idx)
 }

--- a/wallylib/callmapper/callmapper.go
+++ b/wallylib/callmapper/callmapper.go
@@ -63,9 +63,14 @@ type Options struct {
 	SearchAlg    SearchAlgorithm
 	Limiter      LimiterMode
 	SkipClosures bool
+	ModuleOnly   bool
 }
 
 func NewCallMapper(match *match.RouteMatch, nodes map[*ssa.Function]*callgraph.Node, options Options) *CallMapper {
+	// Rather than adding another state to check for, this is easier
+	if options.ModuleOnly {
+		options.Filter = match.Module
+	}
 	return &CallMapper{
 		Options:        options,
 		Match:          match,
@@ -102,32 +107,32 @@ func (cm *CallMapper) initPath(s *callgraph.Node) []string {
 	return initialPath
 }
 
-func (cm *CallMapper) AllPathsBFS(s *callgraph.Node, options Options) *match.CallPaths {
+func (cm *CallMapper) AllPathsBFS(s *callgraph.Node) *match.CallPaths {
 	initialPath := cm.initPath(s)
 	callPaths := &match.CallPaths{}
-	cm.BFS(s, initialPath, callPaths, options)
+	cm.BFS(s, initialPath, callPaths)
 	return callPaths
 }
 
-func (cm *CallMapper) AllPathsDFS(s *callgraph.Node, options Options) *match.CallPaths {
+func (cm *CallMapper) AllPathsDFS(s *callgraph.Node) *match.CallPaths {
 	visited := make(map[int]bool)
 	initialPath := cm.initPath(s)
 	callPaths := &match.CallPaths{}
 	callPaths.Paths = []*match.CallPath{}
-	cm.DFS(s, visited, initialPath, callPaths, options, nil)
+	cm.DFS(s, visited, initialPath, callPaths, nil)
 	return callPaths
 }
 
-func (cm *CallMapper) DFS(destination *callgraph.Node, visited map[int]bool, path []string, paths *match.CallPaths, options Options, site ssa.CallInstruction) {
-	newPath := cm.appendNodeToPath(destination, path, options, site)
+func (cm *CallMapper) DFS(destination *callgraph.Node, visited map[int]bool, path []string, paths *match.CallPaths, site ssa.CallInstruction) {
+	newPath := cm.appendNodeToPath(destination, path, site)
 
-	if options.Limiter > 0 && isMainFunc(destination) {
+	if cm.Options.Limiter > 0 && isMainFunc(destination) {
 		paths.InsertPaths(newPath, false, false)
 		cm.Stop = false
 		return
 	}
 
-	mustStop := options.MaxFuncs > 0 && len(newPath) >= options.MaxFuncs
+	mustStop := cm.Options.MaxFuncs > 0 && len(newPath) >= cm.Options.MaxFuncs
 	if len(destination.In) == 0 || mustStop || cm.Stop {
 		paths.InsertPaths(newPath, mustStop, cm.Stop)
 		cm.Stop = false
@@ -148,14 +153,14 @@ func (cm *CallMapper) DFS(destination *callgraph.Node, visited map[int]bool, pat
 	allOutsideMainPkg := true
 
 	fnT := destination
-	if options.Limiter >= Strict || options.SkipClosures {
+	if cm.Options.Limiter >= Strict || cm.Options.SkipClosures {
 		if isClosure(destination.Func) {
 			encEdges := cm.CallgraphNodes[destination.Func.Parent()]
 			fnT = encEdges
 		}
 	}
 	for _, e := range fnT.In {
-		if paths.Paths != nil && options.MaxPaths > 0 && len(paths.Paths) >= options.MaxPaths {
+		if paths.Paths != nil && cm.Options.MaxPaths > 0 && len(paths.Paths) >= cm.Options.MaxPaths {
 			cm.Match.SSA.PathLimited = true
 			continue
 		}
@@ -163,13 +168,13 @@ func (cm *CallMapper) DFS(destination *callgraph.Node, visited map[int]bool, pat
 			continue
 		}
 
-		if !shouldSkipNode(e, options) {
-			if mainPkgLimited(destination, e, options) {
+		if !shouldSkipNode(e, cm.Options) {
+			if mainPkgLimited(destination, e, cm.Options) {
 				continue
 			}
 			allOutsideMainPkg = false
 			allOutsideModule = false
-			cm.DFS(e.Caller, visited, newPath, paths, options, e.Site)
+			cm.DFS(e.Caller, visited, newPath, paths, e.Site)
 		}
 	}
 	if allOutsideModule {
@@ -184,7 +189,7 @@ func (cm *CallMapper) DFS(destination *callgraph.Node, visited map[int]bool, pat
 	}
 }
 
-func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *match.CallPaths, options Options) {
+func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *match.CallPaths) {
 	queue := list.New()
 	queue.PushBack(BFSNode{Node: start, Path: initialPath})
 
@@ -200,22 +205,22 @@ func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *ma
 		currentNode := current.Node
 		currentPath := current.Path
 
-		if options.Limiter > None && isMainFunc(currentNode) {
+		if cm.Options.Limiter > None && isMainFunc(currentNode) {
 			paths.InsertPaths(currentPath, false, false)
 			continue
 		}
 
 		// Are we out of nodes for this currentNode, or have we reached the limit of funcs in a path?
-		if limitFuncsReached(currentPath, options) {
+		if limitFuncsReached(currentPath, cm.Options) {
 			paths.InsertPaths(currentPath, true, false)
 			continue
 		}
 
-		newPath := cm.appendNodeToPath(currentNode, currentPath, options, nil)
+		newPath := cm.appendNodeToPath(currentNode, currentPath, nil)
 
 		// If we are not interested in closure call maps (which can often be incorrect) we instead worry about the enclosing
 		// func and not the closure
-		if options.Limiter >= Strict || options.SkipClosures {
+		if cm.Options.Limiter >= Strict || cm.Options.SkipClosures {
 			if isClosure(currentNode.Func) {
 				encEdges := cm.CallgraphNodes[currentNode.Func.Parent()]
 				currentNode = encEdges
@@ -230,8 +235,8 @@ func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *ma
 			if callerInPath(e, newPath) {
 				continue
 			}
-			if options.Filter == "" || passesFilter(e.Caller, options.Filter) {
-				if mainPkgLimited(currentNode, e, options) {
+			if cm.Options.Filter == "" || passesFilter(e.Caller, cm.Options.Filter) {
+				if mainPkgLimited(currentNode, e, cm.Options) {
 					allAlreadyInPath = false
 					continue
 				}
@@ -243,11 +248,11 @@ func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *ma
 				copy(newPathCopy, newPath)
 
 				// We want to process the new node we added to the path.
-				newPathWithCaller := cm.appendNodeToPath(e.Caller, newPathCopy, options, e.Site)
+				newPathWithCaller := cm.appendNodeToPath(e.Caller, newPathCopy, e.Site)
 				queue.PushBack(BFSNode{Node: e.Caller, Path: newPathWithCaller})
 
 				// Have we reached the max paths set by the user
-				if options.MaxPaths > 0 && queue.Len()+len(paths.Paths) >= options.MaxPaths {
+				if cm.Options.MaxPaths > 0 && queue.Len()+len(paths.Paths) >= cm.Options.MaxPaths {
 					pathLimited = true
 					break
 				}
@@ -257,7 +262,7 @@ func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *ma
 			paths.InsertPaths(currentPath, false, false)
 			continue
 		}
-		if options.Filter != "" && allOutsideFilter {
+		if cm.Options.Filter != "" && allOutsideFilter {
 			paths.InsertPaths(currentPath, false, true)
 			continue
 		}
@@ -349,13 +354,13 @@ func callerInPath(e *callgraph.Edge, paths []string) bool {
 	return false
 }
 
-func (cm *CallMapper) appendNodeToPath(s *callgraph.Node, path []string, options Options, site ssa.CallInstruction) []string {
+func (cm *CallMapper) appendNodeToPath(s *callgraph.Node, path []string, site ssa.CallInstruction) []string {
 	if site == nil {
 		return path
 		//return append(path, fmt.Sprintf("Func: %s.[%s] %s", s.Func.Pkg.Pkg.Name(), s.Func.Name(), wallylib.GetFormattedPos(s.Func.Package(), s.Func.Pos())))
 	}
 
-	if options.PrintNodes || s.Func.Package() == nil {
+	if cm.Options.PrintNodes || s.Func.Package() == nil {
 		return append(path, s.String())
 	}
 

--- a/wallylib/callmapper/callmapper.go
+++ b/wallylib/callmapper/callmapper.go
@@ -363,27 +363,6 @@ func (cm *CallMapper) appendNodeToPath(s *callgraph.Node, path []string, options
 	return append(path, nodeDescription)
 }
 
-//func (cm *CallMapper) getNodeString(basePos string, pkg *ssa.Package, function *ssa.Function, s *callgraph.Node) string {
-//	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
-//
-//	if function.Recover != nil {
-//		return cm.getRecoverString(pkg, function, function.Recover.Index-1, basePos)
-//	} else if s != nil && strings.Contains(function.Name(), "$") {
-//		enclosingFunc := closureArgumentOf(s, cm.CallgraphNodes[s.Func.Parent()])
-//		if enclosingFunc != nil && enclosingFunc.Recover != nil {
-//			return cm.getRecoverString(pkg, enclosingFunc, enclosingFunc.Recover.Index-1, basePos)
-//		}
-//		if enclosingFunc != nil {
-//			for _, af := range enclosingFunc.AnonFuncs {
-//				if af.Recover != nil {
-//					return cm.getRecoverString(pkg, af, af.Recover.Index-1, basePos)
-//				}
-//			}
-//		}
-//	}
-//	return baseStr
-//}
-
 func (cm *CallMapper) getNodeString(basePos string, pkg *ssa.Package, function *ssa.Function, s *callgraph.Node) string {
 	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
 
@@ -440,61 +419,6 @@ func (cm *CallMapper) getRecoverString(pkg *ssa.Package, function *ssa.Function,
 	}
 	return fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
 }
-
-//func (cm *CallMapper) getNodeString(basePos string, pkg *ssa.Package, function *ssa.Function, s *callgraph.Node) string {
-//	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
-//	if function.Recover != nil {
-//		recoverIdx := 0
-//		if function.Recover != nil {
-//			recoverIdx = function.Recover.Index
-//		}
-//		rec, err := findDeferRecover(function, recoverIdx)
-//		if err != nil {
-//			baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
-//		}
-//		if rec {
-//			baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
-//		}
-//	} else if s != nil && strings.Contains(function.Name(), "$") {
-//		enc := closureArgumentOf(s, cm.CallgraphNodes[s.Func.Parent()])
-//		if enc != nil {
-//			if enc.Recover != nil {
-//				rec, err := findDeferRecover(enc, enc.Recover.Index-1)
-//				if err != nil {
-//					baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
-//				}
-//				if rec {
-//					baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
-//				}
-//			} else {
-//				for _, an := range enc.AnonFuncs {
-//					if an.Recover != nil {
-//						rec, err := findDeferRecover(enc, an.Recover.Index-1)
-//						if err != nil {
-//							baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
-//						}
-//						if rec {
-//							baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
-//						}
-//					}
-//				}
-//			}
-//
-//		}
-//	}
-//	//} else {
-//	//	if strings.Contains(function.Name(), "$") {
-//	//		rec, err := findDeferRecover(function, function.Recover.Index-1)
-//	//		if err != nil {
-//	//			baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
-//	//		}
-//	//		if rec {
-//	//			baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
-//	//		}
-//	//	}
-//	//}
-//	return baseStr
-//}
 
 func findDeferRecover(fn *ssa.Function, idx int) (bool, error) {
 	visited := make(map[*ssa.Function]bool)

--- a/wallylib/callmapper/callmapper.go
+++ b/wallylib/callmapper/callmapper.go
@@ -275,42 +275,21 @@ func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *ma
 	}
 }
 
-func (cm *CallMapper) getEnclosingFunctionString(enc *ssa.Function, pkg *ssa.Package, function *ssa.Function, basePos string) string {
-	if enc.Recover != nil {
-		return cm.getRecoverString(pkg, function, enc.Recover.Index-1, basePos)
-	}
-	for _, anonFunc := range enc.AnonFuncs {
-		if anonFunc.Recover != nil {
-			return cm.getRecoverString(pkg, function, anonFunc.Recover.Index-1, basePos)
-		}
-	}
-	return fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
-}
-
-func (cm *CallMapper) getRecoverString(pkg *ssa.Package, function *ssa.Function, recoverIdx int, basePos string) string {
-	rec, err := findDeferRecover(function, recoverIdx)
-	if err != nil {
-		return fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
-	}
-	if rec {
-		return fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
-	}
-	return fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
-}
-
-// argumentOf checks if the function is passed as an argument to another function
-func argumentOf(targetNode *callgraph.Node, parentNode *callgraph.Node) *ssa.Function {
-	for _, edge := range parentNode.Out {
+// isFunctionPassedAsArgument checks if the function is passed as an argument to another function
+func isFunctionPassedAsArgument(targetNode *callgraph.Node, nodes *callgraph.Node) *ssa.Function {
+	//for _, node := range nodes. {
+	for _, edge := range nodes.Out {
 		for _, arg := range edge.Site.Common().Args {
-			if closure, ok := arg.(*ssa.MakeClosure); ok {
-				if closure.Fn == targetNode.Func {
-					if parentFunc, ok := edge.Site.Common().Value.(*ssa.Function); ok {
-						return parentFunc
+			if argFn, ok := arg.(*ssa.MakeClosure); ok {
+				if argFn.Fn == targetNode.Func {
+					if res, ok := edge.Site.Common().Value.(*ssa.Function); ok {
+						return res
 					}
 				}
 			}
 		}
 	}
+	//}
 	return nil
 }
 
@@ -394,15 +373,88 @@ func (cm *CallMapper) getNodeString(basePos string, pkg *ssa.Package, function *
 	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
 
 	if function.Recover != nil {
-		return cm.getRecoverString(pkg, function, function.Recover.Index, basePos)
+		return cm.getRecoverString(pkg, function, function.Recover.Index-1, basePos)
 	} else if s != nil && strings.Contains(function.Name(), "$") {
-		enclosingFunc := argumentOf(s, cm.CallgraphNodes[s.Func.Parent()])
+		enclosingFunc := isFunctionPassedAsArgument(s, cm.CallgraphNodes[s.Func.Parent()])
+		if enclosingFunc != nil && enclosingFunc.Recover != nil {
+			return cm.getRecoverString(pkg, enclosingFunc, enclosingFunc.Recover.Index-1, basePos)
+		}
 		if enclosingFunc != nil {
-			return cm.getEnclosingFunctionString(enclosingFunc, pkg, function, basePos)
+			for _, af := range enclosingFunc.AnonFuncs {
+				if af.Recover != nil {
+					return cm.getRecoverString(pkg, af, af.Recover.Index-1, basePos)
+				}
+			}
 		}
 	}
 	return baseStr
 }
+
+func (cm *CallMapper) getRecoverString(pkg *ssa.Package, function *ssa.Function, recoverIdx int, basePos string) string {
+	rec, err := findDeferRecover(function, recoverIdx)
+	if err != nil {
+		return fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
+	}
+	if rec {
+		return fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
+	}
+	return fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
+}
+
+//func (cm *CallMapper) getNodeString(basePos string, pkg *ssa.Package, function *ssa.Function, s *callgraph.Node) string {
+//	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
+//	if function.Recover != nil {
+//		recoverIdx := 0
+//		if function.Recover != nil {
+//			recoverIdx = function.Recover.Index
+//		}
+//		rec, err := findDeferRecover(function, recoverIdx)
+//		if err != nil {
+//			baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
+//		}
+//		if rec {
+//			baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
+//		}
+//	} else if s != nil && strings.Contains(function.Name(), "$") {
+//		enc := isFunctionPassedAsArgument(s, cm.CallgraphNodes[s.Func.Parent()])
+//		if enc != nil {
+//			if enc.Recover != nil {
+//				rec, err := findDeferRecover(enc, enc.Recover.Index-1)
+//				if err != nil {
+//					baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
+//				}
+//				if rec {
+//					baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
+//				}
+//			} else {
+//				for _, an := range enc.AnonFuncs {
+//					if an.Recover != nil {
+//						rec, err := findDeferRecover(enc, an.Recover.Index-1)
+//						if err != nil {
+//							baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
+//						}
+//						if rec {
+//							baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
+//						}
+//					}
+//				}
+//			}
+//
+//		}
+//	}
+//	//} else {
+//	//	if strings.Contains(function.Name(), "$") {
+//	//		rec, err := findDeferRecover(function, function.Recover.Index-1)
+//	//		if err != nil {
+//	//			baseStr = fmt.Sprintf("%s.[%s] (%s) %s", pkg.Pkg.Name(), function.Name(), err.Error(), basePos)
+//	//		}
+//	//		if rec {
+//	//			baseStr = fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
+//	//		}
+//	//	}
+//	//}
+//	return baseStr
+//}
 
 func findDeferRecover(fn *ssa.Function, idx int) (bool, error) {
 	visited := make(map[*ssa.Function]bool)

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -7,6 +7,7 @@ import (
 	"go/build"
 	"go/types"
 	"golang.org/x/tools/go/callgraph"
+	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"wally/indicator"
 )
@@ -259,6 +260,13 @@ func callExprFromExpr(e ast.Expr) []*ast.CallExpr {
 		return GetExprsFromStmt(e.Body)
 	}
 	return nil
+}
+
+func getModuleName(pkg *packages.Package) (string, error) {
+	if pkg.Module != nil {
+		return pkg.Module.Path, nil
+	}
+	return "", fmt.Errorf("module not found for package %s", pkg.PkgPath)
 }
 
 func inStd(node *callgraph.Node) bool {


### PR DESCRIPTION
Improved Route Matching and Call Graph Analysis:  enhancements to the application's route matching and call graph analysis  logic. 

Can now use `--module-only` instead of a filter string to restrict path mapping to each match module. 

Better handling of closures and recoverable functions when detecting recoverable paths

Documentation updates

Refactor of multiple functions for readability and maintainability