### PR TITLE
Simplified mode, exclusions, concurrent path search

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,14 @@ indicators:
 
 Note that you can specify the parameter that you want Wally to attempt to solve the value to. If you don't know the name of the parameter (per the function signature), you can give it the position in the signature. You can then use the `--config` or `-c` flag along with the path to the configuration file.
 
-### Match Filters vs. Path Filters
+### Filtering Matches
+
+You can exclude the following from the analysis performed by Wally
+
+- **Packages**: Using `--exclude-pkg` you can enter a comma separated list of packages that wally will skip when collecting function call matches.
+- **Position**: Using `--exclude-pos` you can enter a comma separated list of code positions for function calls to skip when wally collects matches. Evaluation is suffix based, so you could pass strings like `my_file.go:X:Y` to avoid, for instance, analysis of matches that have a spurious number of paths.
+
+## Match Filters vs. Path Filters
 
 You can provide a match filter or path filters to wally. 
 
@@ -264,6 +271,16 @@ At its core, Wally uses various algorithms available via the [golang.org/x/tools
     - A function node A originating in the `main` _package_ followed by a call to node B inside the `main` function of a different package
     - A function node A originating in the `main` _pacckage_ followed by a function/node B not in the same package _unless_ function/node A is a closure.
 - `0` (none): Wally will construct call paths even past main if reported by the chosen `tools/go/callgraph` algorithm.
+
+#### Simple mode
+
+Using `-s` or `--simple` tells wally to only focus not on call sites but instead the relation between functions. In this mode, wally does the following:
+
+- It constructs paths not based on call sites but on containing functions.
+- Skips line numbers to avoid, for instance, paths within a single enclosing function. In the future we will include the position for the enclosing function.
+- Skips most closures, focusing instead on the enclosing functions
+
+This allows you to get a higher level view of the relation between packages, functions, etc. in your code.
 
 ### Analyzing individual paths
 

--- a/README.md
+++ b/README.md
@@ -277,8 +277,9 @@ At its core, Wally uses various algorithms available via the [golang.org/x/tools
 Using `-s` or `--simple` tells wally to only focus not on call sites but instead the relation between functions. In this mode, wally does the following:
 
 - It constructs paths not based on call sites but on containing functions.
-- Skips line numbers to avoid, for instance, paths within a single enclosing function. In the future we will include the position for the enclosing function.
-- Skips most closures, focusing instead on the enclosing functions
+- It skips call sites
+- Skips closures, focusing instead on the enclosing functions
+- Removes duplicates, as this kinda of analysis would result in duplicated results otherwise
 
 This allows you to get a higher level view of the relation between packages, functions, etc. in your code.
 

--- a/cmd/map.go
+++ b/cmd/map.go
@@ -18,23 +18,25 @@ var (
 	config      string
 	wallyConfig WallyConfig
 
-	paths        []string
-	runSSA       bool
-	filter       string
-	graph        string
-	maxFuncs     int
-	maxPaths     int
-	printNodes   bool
-	format       string
-	outputFile   string
-	serverGraph  bool
-	skipDefault  bool
-	limiterMode  int
-	searchAlg    string
-	callgraphAlg string
-	skipClosures bool
-	moduleOnly   bool
-	simplify     bool
+	paths              []string
+	runSSA             bool
+	filter             string
+	graph              string
+	maxFuncs           int
+	maxPaths           int
+	printNodes         bool
+	format             string
+	outputFile         string
+	serverGraph        bool
+	skipDefault        bool
+	limiterMode        int
+	searchAlg          string
+	callgraphAlg       string
+	skipClosures       bool
+	moduleOnly         bool
+	simplify           bool
+	excludePkgs        []string
+	excluseByPosSuffix []string
 )
 
 // mapCmd represents the map command
@@ -91,6 +93,9 @@ func init() {
 	mapCmd.PersistentFlags().StringVar(&format, "format", "", "Output format. Supported: json, csv")
 	mapCmd.PersistentFlags().StringVarP(&outputFile, "out", "o", "", "Output to file path")
 
+	mapCmd.PersistentFlags().StringSliceVar(&excludePkgs, "exclude-pkg", []string{}, "Exclude packages")
+	mapCmd.PersistentFlags().StringSliceVar(&excluseByPosSuffix, "exclude-pos", []string{}, "Package prefix used for filtering the selected function call matches")
+
 	mapCmd.PersistentFlags().BoolVar(&serverGraph, "server", false, "Starts a server on port 1984 with output graph")
 }
 
@@ -101,6 +106,10 @@ func mapRoutes(cmd *cobra.Command, args []string) {
 	nav := navigator.NewNavigator(verbose, indicators)
 	nav.RunSSA = runSSA
 	nav.CallgraphAlg = callgraphAlg
+	nav.Exclusions = navigator.Exclusions{
+		Packages:    excludePkgs,
+		PosSuffixes: excluseByPosSuffix,
+	}
 
 	nav.Logger.Info("Running mapper", "indicators", len(indicators))
 

--- a/cmd/map.go
+++ b/cmd/map.go
@@ -93,8 +93,8 @@ func init() {
 	mapCmd.PersistentFlags().StringVar(&format, "format", "", "Output format. Supported: json, csv")
 	mapCmd.PersistentFlags().StringVarP(&outputFile, "out", "o", "", "Output to file path")
 
-	mapCmd.PersistentFlags().StringSliceVar(&excludePkgs, "exclude-pkg", []string{}, "Exclude packages")
-	mapCmd.PersistentFlags().StringSliceVar(&excluseByPosSuffix, "exclude-pos", []string{}, "Package prefix used for filtering the selected function call matches")
+	mapCmd.PersistentFlags().StringSliceVar(&excludePkgs, "exclude-pkg", []string{}, "Comma separated list of packages to exclude")
+	mapCmd.PersistentFlags().StringSliceVar(&excluseByPosSuffix, "exclude-pos", []string{}, "Comma separated list of position prefixes used for filtering the selected function call matches")
 
 	mapCmd.PersistentFlags().BoolVar(&serverGraph, "server", false, "Starts a server on port 1984 with output graph")
 }

--- a/cmd/map.go
+++ b/cmd/map.go
@@ -34,6 +34,7 @@ var (
 	callgraphAlg string
 	skipClosures bool
 	moduleOnly   bool
+	simplify     bool
 )
 
 // mapCmd represents the map command
@@ -77,6 +78,7 @@ func init() {
 	mapCmd.PersistentFlags().StringVar(&callgraphAlg, "callgraph-alg", "cha", "cha || rta || vta")
 	mapCmd.PersistentFlags().BoolVar(&skipClosures, "skip-closures", false, "Skip closure edges which can lead to innacurate results")
 	mapCmd.PersistentFlags().BoolVar(&moduleOnly, "module-only", true, "Filter call paths by the match module.")
+	mapCmd.PersistentFlags().BoolVarP(&simplify, "simple", "s", false, "Simple output focuses on function signatures rather than sites")
 
 	mapCmd.PersistentFlags().StringSliceVarP(&paths, "paths", "p", paths, "The comma separated package paths to target. Use ./.. for current directory and subdirectories")
 	mapCmd.PersistentFlags().StringVarP(&graph, "graph", "g", "", "Path for optional PNG graph output. Only works with --ssa")
@@ -119,6 +121,7 @@ func mapRoutes(cmd *cobra.Command, args []string) {
 			Limiter:      callmapper.LimiterMode(limiterMode),
 			SkipClosures: skipClosures,
 			ModuleOnly:   moduleOnly,
+			Simplify:     simplify,
 		}
 		nav.Logger.Info("Solving call paths for matches", "matches", len(nav.RouteMatches))
 		nav.SolveCallPaths(mapperOptions)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -74,6 +74,7 @@ func searchFunc(cmd *cobra.Command, args []string) {
 		}, true,
 	)
 
+	fmt.Println(len(matchFilters))
 	nav := navigator.NewNavigator(verbose, indicators)
 	nav.RunSSA = true
 	nav.CallgraphAlg = callgraphAlg

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -16,6 +16,7 @@ var (
 	function     string
 	recvType     string
 	matchFilters []string
+	skipLine     bool
 )
 
 // funcCmd represents the map command
@@ -56,6 +57,7 @@ func init() {
 	funcCmd.PersistentFlags().StringVar(&function, "func", "", "Function name")
 	funcCmd.PersistentFlags().StringVar(&recvType, "recv-type", "", "receiver type name (excluding package)")
 	funcCmd.PersistentFlags().StringSliceVar(&matchFilters, "match-filter", []string{}, "Package prefix used for filtering the selected function call matches")
+	funcCmd.PersistentFlags().BoolVar(&skipLine, "skip-line", false, "Skip line")
 	funcCmd.MarkPersistentFlagRequired("pkg")
 	funcCmd.MarkPersistentFlagRequired("func")
 }
@@ -89,6 +91,7 @@ func searchFunc(cmd *cobra.Command, args []string) {
 		SearchAlg:    callmapper.SearchAlgs[searchAlg],
 		SkipClosures: skipClosures,
 		ModuleOnly:   moduleOnly,
+		SkipLine:     skipLine,
 	}
 
 	nav.Logger.Info("Running mapper", "indicators", len(indicators))

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -16,7 +16,7 @@ var (
 	function     string
 	recvType     string
 	matchFilters []string
-	skipLine     bool
+	simplify     bool
 )
 
 // funcCmd represents the map command
@@ -57,7 +57,7 @@ func init() {
 	funcCmd.PersistentFlags().StringVar(&function, "func", "", "Function name")
 	funcCmd.PersistentFlags().StringVar(&recvType, "recv-type", "", "receiver type name (excluding package)")
 	funcCmd.PersistentFlags().StringSliceVar(&matchFilters, "match-filter", []string{}, "Package prefix used for filtering the selected function call matches")
-	funcCmd.PersistentFlags().BoolVar(&skipLine, "skip-line", false, "Skip line")
+	funcCmd.PersistentFlags().BoolVar(&simplify, "skip-line", false, "Skip line")
 	funcCmd.MarkPersistentFlagRequired("pkg")
 	funcCmd.MarkPersistentFlagRequired("func")
 }
@@ -74,10 +74,6 @@ func searchFunc(cmd *cobra.Command, args []string) {
 		}, true,
 	)
 
-	for _, mf := range indicators[0].MatchFilters {
-		fmt.Println("match filter: ", mf)
-	}
-
 	nav := navigator.NewNavigator(verbose, indicators)
 	nav.RunSSA = true
 	nav.CallgraphAlg = callgraphAlg
@@ -91,7 +87,7 @@ func searchFunc(cmd *cobra.Command, args []string) {
 		SearchAlg:    callmapper.SearchAlgs[searchAlg],
 		SkipClosures: skipClosures,
 		ModuleOnly:   moduleOnly,
-		SkipLine:     skipLine,
+		Simplify:     simplify,
 	}
 
 	nav.Logger.Info("Running mapper", "indicators", len(indicators))

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	pkg         string
-	function    string
-	recvType    string
-	matchFilter string
+	pkg          string
+	function     string
+	recvType     string
+	matchFilters []string
 )
 
 // funcCmd represents the map command
@@ -55,7 +55,7 @@ func init() {
 	funcCmd.PersistentFlags().StringVar(&pkg, "pkg", "", "Package name")
 	funcCmd.PersistentFlags().StringVar(&function, "func", "", "Function name")
 	funcCmd.PersistentFlags().StringVar(&recvType, "recv-type", "", "receiver type name (excluding package)")
-	funcCmd.PersistentFlags().StringVar(&matchFilter, "match-filter", "", "Package prefix used for filtering the selected function call matches")
+	funcCmd.PersistentFlags().StringSliceVar(&matchFilters, "match-filter", []string{}, "Package prefix used for filtering the selected function call matches")
 	funcCmd.MarkPersistentFlagRequired("pkg")
 	funcCmd.MarkPersistentFlagRequired("func")
 }
@@ -63,14 +63,18 @@ func init() {
 func searchFunc(cmd *cobra.Command, args []string) {
 	indicators := indicator.InitIndicators(
 		[]indicator.Indicator{
-			indicator.Indicator{
+			{
 				Package:      pkg,
 				Function:     function,
 				ReceiverType: recvType,
-				MatchFilter:  matchFilter,
+				MatchFilters: matchFilters,
 			},
 		}, true,
 	)
+
+	for _, mf := range indicators[0].MatchFilters {
+		fmt.Println("match filter: ", mf)
+	}
 
 	nav := navigator.NewNavigator(verbose, indicators)
 	nav.RunSSA = true

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -16,7 +16,6 @@ var (
 	function     string
 	recvType     string
 	matchFilters []string
-	simplify     bool
 )
 
 // funcCmd represents the map command
@@ -57,7 +56,6 @@ func init() {
 	funcCmd.PersistentFlags().StringVar(&function, "func", "", "Function name")
 	funcCmd.PersistentFlags().StringVar(&recvType, "recv-type", "", "receiver type name (excluding package)")
 	funcCmd.PersistentFlags().StringSliceVar(&matchFilters, "match-filter", []string{}, "Package prefix used for filtering the selected function call matches")
-	funcCmd.PersistentFlags().BoolVar(&simplify, "skip-line", false, "Skip line")
 	funcCmd.MarkPersistentFlagRequired("pkg")
 	funcCmd.MarkPersistentFlagRequired("func")
 }

--- a/indicator/indicator.go
+++ b/indicator/indicator.go
@@ -24,7 +24,7 @@ type Indicator struct {
 	Params        []RouteParam  `yaml:"params"`
 	IndicatorType IndicatorType `yaml:"indicatorType"`
 	ReceiverType  string        `yaml:"receiverType"`
-	MatchFilter   string        `yaml:"matchFilter"`
+	MatchFilters  []string      `yaml:"matchFilter"`
 }
 
 type RouteParam struct {
@@ -69,7 +69,7 @@ func getStockIndicators() []Indicator {
 				{Name: "pattern"},
 			},
 			IndicatorType: Service,
-			MatchFilter:   "",
+			MatchFilters:  []string{},
 		},
 		{
 			Id:       "2",
@@ -80,7 +80,7 @@ func getStockIndicators() []Indicator {
 				{Name: "method"},
 			},
 			IndicatorType: Service,
-			MatchFilter:   "",
+			MatchFilters:  []string{},
 		},
 	}
 }

--- a/match/match.go
+++ b/match/match.go
@@ -64,7 +64,6 @@ func (cp *CallPaths) InsertPaths(nodes []wallynode.WallyNode, nodeLimited bool, 
 	if simplify {
 		for _, existingPath := range cp.Paths {
 			if isSamePath(existingPath, nodes) {
-
 				return
 			}
 		}

--- a/match/match.go
+++ b/match/match.go
@@ -38,24 +38,10 @@ type CallPaths struct {
 
 type CallPath struct {
 	ID            int
-	Nodes         []*Node
+	Nodes         []wallynode.WallyNode
 	NodeLimited   bool
 	FilterLimited bool
 	Recoverable   bool
-}
-
-type NodeType int
-
-const (
-	Site NodeType = iota
-	Function
-)
-
-type Node struct {
-	NodeType   NodeType
-	NodeString string
-	Pkg        *ssa.Package
-	Func       *ssa.Function
 }
 
 func (cp *CallPaths) InsertPaths(nodes []wallynode.WallyNode, nodeLimited bool, filterLimited bool, simplify bool) {
@@ -75,9 +61,9 @@ func (cp *CallPaths) InsertPaths(nodes []wallynode.WallyNode, nodeLimited bool, 
 		if simplify && node.Site != nil {
 			continue
 		}
-		callPath.Nodes = append(callPath.Nodes, &Node{NodeString: node.NodeString})
+		callPath.Nodes = append(callPath.Nodes, node)
 		// Temp hack while we replace nodes with a structure containing parts of a path (func, pkg, etc.)
-		if node.Recoverable {
+		if node.IsRecoverable() {
 			callPath.Recoverable = true
 		}
 	}

--- a/match/match.go
+++ b/match/match.go
@@ -63,7 +63,6 @@ func (cp *CallPaths) InsertPaths(nodes []string, nodeLimited bool, filterLimited
 	// as there can be multiple call sites inside the same enclosing function
 	if simplify {
 		for _, existingPath := range cp.Paths {
-			fmt.Println("Duplicate deleted")
 			if isSamePath(existingPath, nodes) {
 				return
 			}

--- a/match/match.go
+++ b/match/match.go
@@ -72,6 +72,9 @@ func (cp *CallPaths) InsertPaths(nodes []string, nodeLimited bool, filterLimited
 	callPath := CallPath{NodeLimited: nodeLimited, FilterLimited: filterLimited}
 
 	for _, node := range nodes {
+		if !strings.HasPrefix(node, "Func:") {
+			continue
+		}
 		callPath.Nodes = append(callPath.Nodes, &Node{NodeString: node})
 		// Temp hack while we replace nodes with a structure containing parts of a path (func, pkg, etc.)
 		if strings.Contains(node, "(recoverable)") {

--- a/navigator/navigator.go
+++ b/navigator/navigator.go
@@ -279,6 +279,12 @@ func (n *Navigator) Run(pass *analysis.Pass) (interface{}, error) {
 			}
 		}
 
+		if funcMatch.EnclosedBy == "" {
+			if decl := callMapper.EnclosingFunc(ce); decl != nil {
+				funcMatch.EnclosedBy = fmt.Sprintf("%s.%s", pass.Pkg.Name(), decl.Name.String())
+			}
+		}
+
 		results = append(results, funcMatch)
 	})
 

--- a/navigator/navigator.go
+++ b/navigator/navigator.go
@@ -244,9 +244,7 @@ func (n *Navigator) Run(pass *analysis.Pass) (interface{}, error) {
 
 		// Get the position of the function in code
 		pos := pass.Fset.Position(funExpr.Pos())
-		funcInfo.Pos = pos
-
-		if !n.PassesExclusions(funcInfo) {
+		if !n.PassesExclusions(pos, funcInfo.Package) {
 			return
 		}
 
@@ -321,19 +319,19 @@ func (n *Navigator) GetCallInstructionFromSSAFunc(enclosingFunc *ssa.Function, e
 	return nil
 }
 
-func (n *Navigator) PassesExclusions(funcInfo *wallylib.FuncInfo) bool {
+func (n *Navigator) PassesExclusions(pos token.Position, pkg string) bool {
 	if len(n.Exclusions.Packages) == 0 && len(n.Exclusions.PosSuffixes) == 0 {
 		return true
 	}
 
 	for _, pkg := range n.Exclusions.Packages {
-		if funcInfo.Package == pkg {
+		if pkg == pkg {
 			return false
 		}
 	}
 
 	for _, exc := range n.Exclusions.PosSuffixes {
-		if strings.HasSuffix(funcInfo.Pos.String(), exc) {
+		if strings.HasSuffix(pos.String(), exc) {
 			return false
 		}
 	}

--- a/wallylib/callmapper/callmapper.go
+++ b/wallylib/callmapper/callmapper.go
@@ -314,6 +314,7 @@ func (cm *CallMapper) BFS(start *callgraph.Node, initialPath []string, paths *ma
 }
 
 // closureArgumentOf checks if the function is passed as an argument to another function
+// and returns the enclosing function
 func closureArgumentOf(targetNode *callgraph.Node, edges *callgraph.Node) *ssa.Function {
 	for _, edge := range edges.Out {
 		for _, arg := range edge.Site.Common().Args {

--- a/wallylib/callmapper/callmapper.go
+++ b/wallylib/callmapper/callmapper.go
@@ -88,7 +88,7 @@ func NewCallMapper(match *match.RouteMatch, nodes map[*ssa.Function]*callgraph.N
 func (cm *CallMapper) initPath(s *callgraph.Node) []wallynode.WallyNode {
 	encPkg := cm.Match.SSA.EnclosedByFunc.Pkg
 	encBasePos := wallylib.GetFormattedPos(encPkg, cm.Match.SSA.EnclosedByFunc.Pos())
-	rec := cm.NodeFactory.IsRecoverable(s)
+	rec := wallynode.IsRecoverable(s, cm.CallgraphNodes)
 	encStr := wallynode.GetNodeString(encBasePos, s, rec)
 
 	if cm.Options.Simplify {
@@ -109,7 +109,7 @@ func (cm *CallMapper) initPath(s *callgraph.Node) []wallynode.WallyNode {
 			siteStr = fmt.Sprintf("%s.[%s] %s", sitePkg.Pkg.Name(), cm.Match.Indicator.Function, siteBasePos)
 		} else {
 			targetFuncNode := cm.CallgraphNodes[cm.Match.SSA.SSAFunc]
-			isRec := cm.NodeFactory.IsRecoverable(targetFuncNode)
+			isRec := wallynode.IsRecoverable(targetFuncNode, cm.CallgraphNodes)
 			siteStr = wallynode.GetNodeString(siteBasePos, targetFuncNode, isRec)
 		}
 		cm.Match.SSA.TargetPos = siteStr

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -40,6 +40,7 @@ type SSAContext struct {
 
 func (fi *FuncInfo) Match(indicators []indicator.Indicator) *indicator.Indicator {
 	var match *indicator.Indicator
+	
 	for _, ind := range indicators {
 		ind := ind
 
@@ -58,10 +59,17 @@ func (fi *FuncInfo) Match(indicators []indicator.Indicator) *indicator.Indicator
 			}
 		}
 
-		if ind.MatchFilter != "" && fi.EnclosedBy.Pkg != nil {
-			if !strings.HasPrefix(fi.EnclosedBy.Pkg.Path(), ind.MatchFilter) {
-				continue
+		filterMatch := false
+		for _, mf := range ind.MatchFilters {
+			if mf != "" && fi.EnclosedBy.Pkg != nil {
+				if strings.HasPrefix(fi.EnclosedBy.Pkg.Path(), mf) {
+					filterMatch = true
+					continue
+				}
 			}
+		}
+		if !filterMatch {
+			continue
 		}
 
 		match = &ind

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -343,6 +343,10 @@ func GetFunctionFromSite(site ssa.CallInstruction) *ssa.Function {
 	}
 }
 
+func IsClosure(function *ssa.Function) bool {
+	return strings.Contains(function.Name(), "$")
+}
+
 func getModuleName(pkg *packages.Package) (string, error) {
 	if pkg.Module != nil {
 		return pkg.Module.Path, nil

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -60,16 +60,18 @@ func (fi *FuncInfo) Match(indicators []indicator.Indicator) *indicator.Indicator
 		}
 
 		filterMatch := false
-		for _, mf := range ind.MatchFilters {
-			if mf != "" && fi.EnclosedBy.Pkg != nil {
-				if strings.HasPrefix(fi.EnclosedBy.Pkg.Path(), mf) {
-					filterMatch = true
-					continue
+		if len(ind.MatchFilters) > 0 {
+			for _, mf := range ind.MatchFilters {
+				if mf != "" && fi.EnclosedBy.Pkg != nil {
+					if strings.HasPrefix(fi.EnclosedBy.Pkg.Path(), mf) {
+						filterMatch = true
+						break
+					}
 				}
 			}
-		}
-		if !filterMatch && len(ind.MatchFilters) > 0 {
-			continue
+			if !filterMatch {
+				continue
+			}
 		}
 
 		match = &ind

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hex0punk/wally/indicator"
 	"go/ast"
 	"go/build"
-	"go/token"
 	"go/types"
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/packages"
@@ -31,7 +30,6 @@ type FuncInfo struct {
 	Route      string
 	Signature  *types.Signature
 	EnclosedBy *FuncDecl
-	Pos        token.Position
 }
 
 type SSAContext struct {

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -40,7 +40,7 @@ type SSAContext struct {
 
 func (fi *FuncInfo) Match(indicators []indicator.Indicator) *indicator.Indicator {
 	var match *indicator.Indicator
-	
+
 	for _, ind := range indicators {
 		ind := ind
 

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -68,7 +68,7 @@ func (fi *FuncInfo) Match(indicators []indicator.Indicator) *indicator.Indicator
 				}
 			}
 		}
-		if !filterMatch {
+		if !filterMatch && len(ind.MatchFilters) > 0 {
 			continue
 		}
 

--- a/wallylib/core.go
+++ b/wallylib/core.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hex0punk/wally/indicator"
 	"go/ast"
 	"go/build"
+	"go/token"
 	"go/types"
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/packages"
@@ -30,6 +31,7 @@ type FuncInfo struct {
 	Route      string
 	Signature  *types.Signature
 	EnclosedBy *FuncDecl
+	Pos        token.Position
 }
 
 type SSAContext struct {

--- a/wallylib/util.go
+++ b/wallylib/util.go
@@ -51,13 +51,10 @@ func IsLocal(obj types.Object) bool {
 	return depth >= 4
 }
 
-func GetFormattedPos(pkg *ssa.Package, pos token.Pos, ignoreLineAndCol bool) string {
+func GetFormattedPos(pkg *ssa.Package, pos token.Pos) string {
 	fs := pkg.Prog.Fset
 	p := fs.Position(pos)
 	currentPath, _ := os.Getwd()
 	relPath, _ := filepath.Rel(currentPath, p.Filename)
-	if ignoreLineAndCol {
-		return fmt.Sprintf("%s", relPath)
-	}
 	return fmt.Sprintf("%s:%d:%d", relPath, p.Line, p.Column)
 }

--- a/wallylib/util.go
+++ b/wallylib/util.go
@@ -51,15 +51,13 @@ func IsLocal(obj types.Object) bool {
 	return depth >= 4
 }
 
-func GetFormattedPos(pkg *ssa.Package, pos token.Pos, skipLine bool) string {
+func GetFormattedPos(pkg *ssa.Package, pos token.Pos, ignoreLineAndCol bool) string {
 	fs := pkg.Prog.Fset
 	p := fs.Position(pos)
 	currentPath, _ := os.Getwd()
 	relPath, _ := filepath.Rel(currentPath, p.Filename)
-	if skipLine {
-		fmt.Println("eskiping ", relPath)
+	if ignoreLineAndCol {
 		return fmt.Sprintf("%s", relPath)
 	}
-	fmt.Println("noooot eskiping ", relPath)
 	return fmt.Sprintf("%s:%d:%d", relPath, p.Line, p.Column)
 }

--- a/wallylib/util.go
+++ b/wallylib/util.go
@@ -51,10 +51,15 @@ func IsLocal(obj types.Object) bool {
 	return depth >= 4
 }
 
-func GetFormattedPos(pkg *ssa.Package, pos token.Pos) string {
+func GetFormattedPos(pkg *ssa.Package, pos token.Pos, skipLine bool) string {
 	fs := pkg.Prog.Fset
 	p := fs.Position(pos)
 	currentPath, _ := os.Getwd()
 	relPath, _ := filepath.Rel(currentPath, p.Filename)
+	if skipLine {
+		fmt.Println("eskiping ", relPath)
+		return fmt.Sprintf("%s", relPath)
+	}
+	fmt.Println("noooot eskiping ", relPath)
 	return fmt.Sprintf("%s:%d:%d", relPath, p.Line, p.Column)
 }

--- a/wallynode/factory.go
+++ b/wallynode/factory.go
@@ -1,0 +1,67 @@
+package wallynode
+
+import (
+	"fmt"
+	"github.com/hex0punk/wally/wallylib"
+	"golang.org/x/tools/go/callgraph"
+	"golang.org/x/tools/go/ssa"
+)
+
+type WallyNodeFactory struct {
+	CallgraphNodes map[*ssa.Function]*callgraph.Node
+}
+
+func NewWallyNodeFactory(callGraphnodes map[*ssa.Function]*callgraph.Node) *WallyNodeFactory {
+	return &WallyNodeFactory{
+		CallgraphNodes: callGraphnodes,
+	}
+}
+
+func (f *WallyNodeFactory) CreateWallyNode(nodeStr string, caller *callgraph.Node, site ssa.CallInstruction) WallyNode {
+	recoverable := false
+	if nodeStr == "" {
+		if site == nil {
+			nodeStr = fmt.Sprintf("Func: %s.[%s] %s", caller.Func.Pkg.Pkg.Name(), caller.Func.Name(), wallylib.GetFormattedPos(caller.Func.Package(), caller.Func.Pos()))
+		} else {
+			fp := wallylib.GetFormattedPos(caller.Func.Package(), site.Pos())
+			recoverable = f.IsRecoverable(caller)
+			nodeStr = GetNodeString(fp, caller, recoverable)
+		}
+	}
+	return WallyNode{
+		NodeString:  nodeStr,
+		Caller:      caller,
+		Site:        site,
+		recoverable: recoverable,
+	}
+}
+
+func (f *WallyNodeFactory) IsRecoverable(s *callgraph.Node) bool {
+	function := s.Func
+	if function.Recover != nil {
+		rec, err := findDeferRecover(function, function.Recover.Index-1)
+		if err == nil && rec {
+			return true
+		}
+	}
+	if wallylib.IsClosure(function) {
+		enclosingFunc := closureArgumentOf(s, f.CallgraphNodes[s.Func.Parent()])
+		if enclosingFunc != nil && enclosingFunc.Recover != nil {
+			rec, err := findDeferRecover(enclosingFunc, enclosingFunc.Recover.Index-1)
+			if err == nil && rec {
+				return true
+			}
+		}
+		if enclosingFunc != nil {
+			for _, af := range enclosingFunc.AnonFuncs {
+				if af.Recover != nil {
+					rec, err := findDeferRecover(af, af.Recover.Index-1)
+					if err == nil && rec {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}

--- a/wallynode/wallynode.go
+++ b/wallynode/wallynode.go
@@ -1,0 +1,171 @@
+package wallynode
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hex0punk/wally/wallylib"
+	"golang.org/x/tools/go/callgraph"
+	"golang.org/x/tools/go/ssa"
+)
+
+type WallyNode struct {
+	NodeString  string
+	Caller      *callgraph.Node
+	Site        ssa.CallInstruction
+	Recoverable bool
+}
+
+func NewWallyNode(nodeStr string, caller *callgraph.Node, site ssa.CallInstruction, connectedNodes map[*ssa.Function]*callgraph.Node) WallyNode {
+	recoverable := false
+	if nodeStr == "" {
+		if site == nil {
+			nodeStr = fmt.Sprintf("Func: %s.[%s] %s", caller.Func.Pkg.Pkg.Name(), caller.Func.Name(), wallylib.GetFormattedPos(caller.Func.Package(), caller.Func.Pos()))
+		} else {
+			fp := wallylib.GetFormattedPos(caller.Func.Package(), site.Pos())
+			recoverable = IsRecoverable(caller, connectedNodes)
+			nodeStr = getNodeString(fp, caller, recoverable)
+		}
+	}
+	return WallyNode{
+		NodeString:  nodeStr,
+		Caller:      caller,
+		Site:        site,
+		Recoverable: recoverable,
+	}
+}
+
+func getNodeString(basePos string, s *callgraph.Node, recoverable bool) string {
+	pkg := s.Func.Package()
+	function := s.Func
+	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)
+
+	if recoverable {
+		return fmt.Sprintf("%s.[%s] (recoverable) %s", pkg.Pkg.Name(), function.Name(), basePos)
+	}
+
+	return baseStr
+}
+
+func IsRecoverable(s *callgraph.Node, callgraphNodes map[*ssa.Function]*callgraph.Node) bool {
+	function := s.Func
+	if function.Recover != nil {
+		rec, err := findDeferRecover(function, function.Recover.Index-1)
+		if err == nil && rec {
+			return true
+		}
+	}
+	if wallylib.IsClosure(function) {
+		enclosingFunc := closureArgumentOf(s, callgraphNodes[s.Func.Parent()])
+		if enclosingFunc != nil && enclosingFunc.Recover != nil {
+			rec, err := findDeferRecover(enclosingFunc, enclosingFunc.Recover.Index-1)
+			if err == nil && rec {
+				return true
+			}
+		}
+		if enclosingFunc != nil {
+			for _, af := range enclosingFunc.AnonFuncs {
+				if af.Recover != nil {
+					rec, err := findDeferRecover(af, af.Recover.Index-1)
+					if err == nil && rec {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func findDeferRecover(fn *ssa.Function, idx int) (bool, error) {
+	visited := make(map[*ssa.Function]bool)
+	return findDeferRecoverRecursive(fn, visited, idx)
+}
+
+func findDeferRecoverRecursive(fn *ssa.Function, visited map[*ssa.Function]bool, starterBlock int) (bool, error) {
+	if visited[fn] {
+		return false, nil
+	}
+
+	visited[fn] = true
+
+	// we use starterBlock on first call as we know where the defer call is, then reset it to 0 for subsequent blocks
+	// to find the recover() if there
+	for blockIdx := starterBlock; blockIdx < len(fn.Blocks); blockIdx++ {
+		block := fn.Blocks[blockIdx]
+		for _, instr := range block.Instrs {
+			switch it := instr.(type) {
+			case *ssa.Defer:
+				if call, ok := it.Call.Value.(*ssa.Function); ok {
+					if containsRecoverCall(call) {
+						return true, nil
+					}
+				}
+			case *ssa.Go:
+				if call, ok := it.Call.Value.(*ssa.Function); ok {
+					if containsRecoverCall(call) {
+						return true, nil
+					}
+				}
+			case *ssa.Call:
+				if callee := it.Call.Value; callee != nil {
+					if callee.Name() == "recover" {
+						return true, nil
+					}
+					if nestedFunc, ok := callee.(*ssa.Function); ok {
+						if _, err := findDeferRecoverRecursive(nestedFunc, visited, 0); err != nil {
+							return true, nil
+						}
+					}
+				}
+			case *ssa.MakeClosure:
+				if closureFn, ok := it.Fn.(*ssa.Function); ok {
+					res, err := findDeferRecoverRecursive(closureFn, visited, 0)
+					if err != nil {
+						return false, errors.New("unexpected error finding recover block")
+					}
+					if res {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func containsRecoverCall(fn *ssa.Function) bool {
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if isRecoverCall(instr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isRecoverCall(instr ssa.Instruction) bool {
+	if callInstr, ok := instr.(*ssa.Call); ok {
+		if callee, ok := callInstr.Call.Value.(*ssa.Builtin); ok {
+			return callee.Name() == "recover"
+		}
+	}
+	return false
+}
+
+// closureArgumentOf checks if the function is passed as an argument to another function
+// and returns the enclosing function
+func closureArgumentOf(targetNode *callgraph.Node, edges *callgraph.Node) *ssa.Function {
+	for _, edge := range edges.Out {
+		for _, arg := range edge.Site.Common().Args {
+			if argFn, ok := arg.(*ssa.MakeClosure); ok {
+				if argFn.Fn == targetNode.Func {
+					if res, ok := edge.Site.Common().Value.(*ssa.Function); ok {
+						return res
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/wallynode/wallynode.go
+++ b/wallynode/wallynode.go
@@ -23,7 +23,7 @@ func NewWallyNode(nodeStr string, caller *callgraph.Node, site ssa.CallInstructi
 		} else {
 			fp := wallylib.GetFormattedPos(caller.Func.Package(), site.Pos())
 			recoverable = IsRecoverable(caller, connectedNodes)
-			nodeStr = getNodeString(fp, caller, recoverable)
+			nodeStr = GetNodeString(fp, caller, recoverable)
 		}
 	}
 	return WallyNode{
@@ -34,7 +34,7 @@ func NewWallyNode(nodeStr string, caller *callgraph.Node, site ssa.CallInstructi
 	}
 }
 
-func getNodeString(basePos string, s *callgraph.Node, recoverable bool) string {
+func GetNodeString(basePos string, s *callgraph.Node, recoverable bool) string {
 	pkg := s.Func.Package()
 	function := s.Func
 	baseStr := fmt.Sprintf("%s.[%s] %s", pkg.Pkg.Name(), function.Name(), basePos)

--- a/wallynode/wallynode.go
+++ b/wallynode/wallynode.go
@@ -3,7 +3,6 @@ package wallynode
 import (
 	"errors"
 	"fmt"
-	"github.com/hex0punk/wally/wallylib"
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/ssa"
 )
@@ -12,26 +11,37 @@ type WallyNode struct {
 	NodeString  string
 	Caller      *callgraph.Node
 	Site        ssa.CallInstruction
-	Recoverable bool
+	recoverable bool
 }
 
-func NewWallyNode(nodeStr string, caller *callgraph.Node, site ssa.CallInstruction, connectedNodes map[*ssa.Function]*callgraph.Node) WallyNode {
-	recoverable := false
-	if nodeStr == "" {
-		if site == nil {
-			nodeStr = fmt.Sprintf("Func: %s.[%s] %s", caller.Func.Pkg.Pkg.Name(), caller.Func.Name(), wallylib.GetFormattedPos(caller.Func.Package(), caller.Func.Pos()))
-		} else {
-			fp := wallylib.GetFormattedPos(caller.Func.Package(), site.Pos())
-			recoverable = IsRecoverable(caller, connectedNodes)
-			nodeStr = GetNodeString(fp, caller, recoverable)
-		}
-	}
-	return WallyNode{
-		NodeString:  nodeStr,
-		Caller:      caller,
-		Site:        site,
-		Recoverable: recoverable,
-	}
+type NodeType int
+
+const (
+	Site NodeType = iota
+	Function
+)
+
+//func NewWallyNode(nodeStr string, caller *callgraph.Node, site ssa.CallInstruction, connectedNodes map[*ssa.Function]*callgraph.Node) WallyNode {
+//	recoverable := false
+//	if nodeStr == "" {
+//		if site == nil {
+//			nodeStr = fmt.Sprintf("Func: %s.[%s] %s", caller.Func.Pkg.Pkg.Name(), caller.Func.Name(), wallylib.GetFormattedPos(caller.Func.Package(), caller.Func.Pos()))
+//		} else {
+//			fp := wallylib.GetFormattedPos(caller.Func.Package(), site.Pos())
+//			recoverable = IsRecoverable(caller, connectedNodes)
+//			nodeStr = GetNodeString(fp, caller, recoverable)
+//		}
+//	}
+//	return WallyNode{
+//		NodeString:  nodeStr,
+//		Caller:      caller,
+//		Site:        site,
+//		recoverable: recoverable,
+//	}
+//}
+
+func (n *WallyNode) IsRecoverable() bool {
+	return n.recoverable
 }
 
 func GetNodeString(basePos string, s *callgraph.Node, recoverable bool) string {
@@ -44,36 +54,6 @@ func GetNodeString(basePos string, s *callgraph.Node, recoverable bool) string {
 	}
 
 	return baseStr
-}
-
-func IsRecoverable(s *callgraph.Node, callgraphNodes map[*ssa.Function]*callgraph.Node) bool {
-	function := s.Func
-	if function.Recover != nil {
-		rec, err := findDeferRecover(function, function.Recover.Index-1)
-		if err == nil && rec {
-			return true
-		}
-	}
-	if wallylib.IsClosure(function) {
-		enclosingFunc := closureArgumentOf(s, callgraphNodes[s.Func.Parent()])
-		if enclosingFunc != nil && enclosingFunc.Recover != nil {
-			rec, err := findDeferRecover(enclosingFunc, enclosingFunc.Recover.Index-1)
-			if err == nil && rec {
-				return true
-			}
-		}
-		if enclosingFunc != nil {
-			for _, af := range enclosingFunc.AnonFuncs {
-				if af.Recover != nil {
-					rec, err := findDeferRecover(af, af.Recover.Index-1)
-					if err == nil && rec {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
 }
 
 func findDeferRecover(fn *ssa.Function, idx int) (bool, error) {


### PR DESCRIPTION
- indicator/indicator.go: The changes modify the Indicator struct to use a slice of MatchFilters instead of a single MatchFilter. This provides more flexibility but also increases complexity
- cmd/search.go: The changes modify the searchFunc to use the new matchFilters slice instead of a single matchFilter. 
- match/match.go: The changes focus on improving the efficiency and accuracy of the call path tracking functionality.
- cmd/map.go: The changes introduce new configuration options for excluding matches by pos or packages.
- wallylib/core.go: The changes to the Match function in the FuncInfo struct improve the matching functionality
- navigator/navigator.go:  introduction of exclusions and parallel processing of paths
- wallylib/callmapper/callmapper.go: The changes to the callmapper.go file are aimed at improving the presentation of call paths.
- wallynode/factory.go: Introduces a new WallyNodeFactory for creating WallyNode instances
- wallynode/wallynode.go: Includes functions for analyzing the recoverability of function calls